### PR TITLE
Path of Kerberos Patch corrected.

### DIFF
--- a/gnome-extra/cinnamon-control-center/cinnamon-control-center-2.0.7.ebuild
+++ b/gnome-extra/cinnamon-control-center/cinnamon-control-center-2.0.7.ebuild
@@ -63,7 +63,7 @@ RDEPEND="${COMMON_DEPEND}"
 PDEPEND=">=gnome-extra/cinnamon-1.8.0"
 
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-2-optional-kerberos.patch"
+	epatch "${FILESDIR}/${PN}-optional-kerberos-2.patch"
 	eautoreconf
 	gnome2_src_prepare
 


### PR DESCRIPTION
The path of the kerboros patch was wrong and so the ebuild wouldn't compile. 
