### PR TITLE
The nm-applet-gtk2 ebuild fails if gtk3 is not installed.

### DIFF
--- a/gnome-extra/nm-applet-gtk2/nm-applet-gtk2-0.9.8.8.ebuild
+++ b/gnome-extra/nm-applet-gtk2/nm-applet-gtk2-0.9.8.8.ebuild
@@ -47,6 +47,7 @@ DEPEND="${RDEPEND}
 "
 
 src_configure() {
+	sed -i s/Gtk-3.0/Gtk-2.0/ src/libnm-gtk/Makefile.in
 	gnome2_src_configure \
 		--with-gtkver=2 \
 		--disable-more-warnings \


### PR DESCRIPTION
'NMGtk-1.0.gir' depends on 'Gtk-3.0.gir' which may not exist on some systems.
The sed command changes dependency from 'Gtk-3.0.gir' to 'Gtk-2.0.gir' which is in the gtk2 package.

Steps to reproduce the issue:
 1. unmerge gtk3
 2. emerge nm-applet-gtk2