### PR TITLE
media-gfx/gscan2pdf: dev-perl/config-general renamed to dev-perl/Config-General

### DIFF
--- a/media-gfx/gscan2pdf/gscan2pdf-1.3.0.ebuild
+++ b/media-gfx/gscan2pdf/gscan2pdf-1.3.0.ebuild
@@ -20,7 +20,7 @@ IUSE=""
 DEPEND="sys-devel/gettext"
 
 RDEPEND="dev-lang/perl[ithreads]
-	>=dev-perl/config-general-2.40
+	>=dev-perl/Config-General-2.40
 	>=dev-perl/glib-perl-1.100-r1
 	dev-perl/Goo-Canvas
 	dev-perl/Gtk2-Ex-Simple-List


### PR DESCRIPTION
emerge -auND world threw a warning on this ebuild this morning due to a Perl ebuild in Portage that was renamed.