### PR TITLE
Update wxperl dependency

### DIFF
--- a/games-rpg/unix-runescape-client/unix-runescape-client-4.3.5.ebuild
+++ b/games-rpg/unix-runescape-client/unix-runescape-client-4.3.5.ebuild
@@ -23,7 +23,7 @@ DEPEND="virtual/jre
 		dev-perl/Archive-Extract
 		dev-perl/Config-IniFiles
 		dev-perl/IO-stringy
-		dev-perl/wxperl
+		dev-perl/Wx
 		net-misc/wget
 		media-libs/libpng:1.2
 		alsa-oss? ( media-libs/alsa-oss )


### PR DESCRIPTION
dev-perl/wxperl has been renamed to dev-perl/Wx per [commit 57706d57](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=57706d577385d992a55083ba964af1e571e018a2).