### PR TITLE
[gnome-extra/budgie-desktop] add missing dependency

### DIFF
--- a/gnome-extra/budgie-desktop/budgie-desktop-10.2.5.ebuild
+++ b/gnome-extra/budgie-desktop/budgie-desktop-10.2.5.ebuild
@@ -39,6 +39,7 @@ DEPEND="${RDEPEND}
 	media-libs/cogl:1.0
 	dev-libs/libgee:0.8
 	x11-themes/gnome-themes-standard
+	dev-util/gtk-doc
 "
 src_prepare() {
 	vala_src_prepare


### PR DESCRIPTION
Otherwise automake fails with `automake-1.15: error: cannot open < gtk-doc.make: No such file or directory`.