### PR TITLE
budgie requires newer ibus than stable

### DIFF
--- a/gnome-extra/budgie-desktop/budgie-desktop-10.2.8.ebuild
+++ b/gnome-extra/budgie-desktop/budgie-desktop-10.2.8.ebuild
@@ -41,7 +41,7 @@ DEPEND="${PYTHON_DEPS}
 	media-libs/cogl:1.0
 	dev-libs/libgee:0.8
 	x11-themes/gnome-themes-standard
-	>=app-i18n/ibus-1.5.11
+	>=app-i18n/ibus-1.5.13
 	>=dev-libs/glib-2.44.0
 	dev-util/gtk-doc
 	sys-apps/util-linux


### PR DESCRIPTION
The configuration stage will ask for ibus 1.5.13 over 1.5.12 in the latest available budgie, this should make sure that ibus version is available.