### PR TITLE
[gnome-extra/budgie-desktop] Add pm-utils USE flag to Budgie Desktop

### DIFF
--- a/gnome-extra/budgie-desktop/budgie-desktop-10.2.9.ebuild
+++ b/gnome-extra/budgie-desktop/budgie-desktop-10.2.9.ebuild
@@ -13,11 +13,12 @@ DESCRIPTION="Desktop Environment based on GNOME 3"
 HOMEPAGE="https://evolve-os.com/budgie/"
 EGIT_REPO_URI="https://github.com/${MY_AUTHOR}/${PN}.git"
 EGIT_COMMIT="v${PV}"
-IUSE="+introspection vala"
+IUSE="+introspection pm-utils vala"
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-RDEPEND="sys-power/upower[introspection=]
+RDEPEND="pm-utils? ( sys-power/upower-pm-utils[introspection=] )
+	 !pm-utils? ( sys-power/upower[introspection=] )
 	 >=gnome-base/gnome-menus-3.10.1:=
 	 >=net-wireless/gnome-bluetooth-3.16:=
 	 gnome-base/gnome-session

--- a/gnome-extra/budgie-desktop/metadata.xml
+++ b/gnome-extra/budgie-desktop/metadata.xml
@@ -5,4 +5,7 @@
 		<email>mudler@sabayonlinux.org</email>
 		<name>mudler</name>
 	</maintainer>
+	<use>
+    		<flag name="pm-utils">Adds support for suspend/resume using <pkg>sys-power/upower-pm-utils</pkg> instead of <pkg>sys-power/upower</pkg></flag>
+  	</use>
 </pkgmetadata>


### PR DESCRIPTION
The changes to this ebuild enable the use of [sys-power/upower-pm-utils](https://packages.gentoo.org/packages/sys-power/upower-pm-utils) over [sys-power/upower](https://packages.gentoo.org/packages/sys-power/upower) in building Budgie Desktop.