### PR TITLE
Fix shebang entropy shebang issue

### DIFF
--- a/app-admin/equo/equo-307-r1.ebuild
+++ b/app-admin/equo/equo-307-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1 bash-completion-r1
+
+DESCRIPTION="Entropy Package Manager text-based client"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+
+S="${WORKDIR}/entropy-${PV}/client"
+MISC_DIR="${WORKDIR}/entropy-${PV}/misc"
+
+COMMON_DEPEND="${PYTHON_DEPS}
+	       ~sys-apps/entropy-${PV}[${PYTHON_USEDEP}]"
+DEPEND="${COMMON_DEPEND}
+	app-text/asciidoc"
+RDEPEND="${COMMON_DEPEND}
+	sys-apps/file[python]"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" install
+	newbashcomp "${MISC_DIR}/equo-completion.bash" equo
+
+	python_optimize "${D}/usr/lib/entropy/client"
+}

--- a/app-admin/equo/metadata.xml
+++ b/app-admin/equo/metadata.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
+<use>
+</use>
 </pkgmetadata>
-

--- a/app-admin/matter/matter-307-r1.ebuild
+++ b/app-admin/matter/matter-307-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1 bash-completion-r1
+
+DESCRIPTION="Automated Packages Builder for Portage and Entropy"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+entropy"
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+
+S="${WORKDIR}/entropy-${PV}/${PN}"
+
+DEPEND=""
+RDEPEND="entropy? ( ~sys-apps/entropy-${PV}[${PYTHON_USEDEP}] )
+	sys-apps/file[python]
+	${PYTHON_DEPS}"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	emake DESTDIR="${D}" base-install
+	if use entropy; then
+		emake DESTDIR="${D}" entropysrv-install
+	fi
+
+	python_optimize "${D}/usr/lib/matter"
+}

--- a/app-admin/matter/metadata.xml
+++ b/app-admin/matter/metadata.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
 	<use>
-		<flag name='entropy'>Add Entropy support</flag>
+		<flag name="entropy">Add Entropy support</flag>
 	</use>
 </pkgmetadata>
-

--- a/app-admin/rigo/metadata.xml
+++ b/app-admin/rigo/metadata.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
 	<use>
 		<flag name="passwordless-upgrade">Enable passwordless system upgrades if user is in the entropy group</flag>
 	</use>
 </pkgmetadata>
-

--- a/app-admin/rigo/rigo-307-r1.ebuild
+++ b/app-admin/rigo/rigo-307-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils gnome2-utils fdo-mime python-single-r1
+
+DESCRIPTION="Rigo, the Sabayon Application Browser"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-3"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+passwordless-upgrade"
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+S="${WORKDIR}/entropy-${PV}/rigo"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="${PYTHON_DEPS}
+	|| ( dev-python/pygobject-cairo:3 dev-python/pygobject:3[cairo] )
+	~sys-apps/entropy-${PV}[${PYTHON_USEDEP}]
+	~sys-apps/rigo-daemon-${PV}[${PYTHON_USEDEP}]
+	sys-devel/gettext
+	x11-libs/gtk+:3
+	x11-libs/vte:2.91
+	>=x11-misc/xdg-utils-1.1.0_rc1_p20120319"
+PDEPEND="passwordless-upgrade? ( app-misc/passwordless-upgrade )"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	python_optimize "${D}/usr/lib/rigo/${PN}"
+}
+
+pkg_postinst() {
+	fdo-mime_mime_database_update
+	fdo-mime_desktop_database_update
+}
+
+pkg_postrm() {
+	fdo-mime_mime_database_update
+	fdo-mime_desktop_database_update
+}

--- a/app-misc/magneto-loader/magneto-loader-307-r1.ebuild
+++ b/app-misc/magneto-loader/magneto-loader-307-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1
+
+DESCRIPTION="Official Sabayon Linux Entropy Notification Applet Loader"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+S="${WORKDIR}/entropy-${PV}/magneto"
+
+DEPEND="${PYTHON_DEPS}
+	~sys-apps/magneto-core-${PV}[${PYTHON_USEDEP}]
+	~app-admin/rigo-${PV}[${PYTHON_USEDEP}]"
+RDEPEND="${DEPEND}"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" magneto-loader-install || die "make install failed"
+}

--- a/app-misc/magneto-loader/metadata.xml
+++ b/app-misc/magneto-loader/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-

--- a/kde-misc/magneto-kde/magneto-kde-307-r1.ebuild
+++ b/kde-misc/magneto-kde/magneto-kde-307-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1
+
+DESCRIPTION="Entropy Package Manager notification applet KDE frontend"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+S="${WORKDIR}/entropy-${PV}/magneto"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="~app-misc/magneto-loader-${PV}[${PYTHON_USEDEP}]
+	kde-apps/pykde4
+	dev-python/PyQt4[dbus]
+	${DEPEND}"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" magneto-kde-install
+	python_optimize "${D}/usr/lib/entropy/magneto/magneto/kde"
+}

--- a/kde-misc/magneto-kde/metadata.xml
+++ b/kde-misc/magneto-kde/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-

--- a/sys-apps/entropy-server/entropy-server-307-r1.ebuild
+++ b/sys-apps/entropy-server/entropy-server-307-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1 bash-completion-r1
+
+DESCRIPTION="Entropy Package Manager server-side tools"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+matter"
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+
+S="${WORKDIR}/entropy-${PV}/server"
+
+RDEPEND="~sys-apps/entropy-${PV}[${PYTHON_USEDEP}]
+	matter? ( ~app-admin/matter-${PV}[entropy] )
+	${PYTHON_DEPS}
+	"
+DEPEND="app-text/asciidoc"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	newbashcomp "${S}/eit-completion.bash" eit
+	python_optimize "${D}/usr/lib/entropy/server"
+}

--- a/sys-apps/entropy-server/metadata.xml
+++ b/sys-apps/entropy-server/metadata.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
 	<use>
-		<flag name='matter'>Pull in app-admin/matter</flag>
+		<flag name="matter">Pull in app-admin/matter</flag>
 	</use>
 </pkgmetadata>
-

--- a/sys-apps/entropy/entropy-307-r1.ebuild
+++ b/sys-apps/entropy/entropy-307-r1.ebuild
@@ -1,0 +1,108 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="sqlite"
+
+inherit eutils python-single-r1 user
+
+DESCRIPTION="Entropy Package Manager foundation library"
+HOMEPAGE="http://www.sabayon.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~ppc64 ~x86"
+
+IUSE=""
+SRC_URI="mirror://sabayon/${CATEGORY}/${P}.tar.bz2"
+
+RDEPEND=">=app-misc/pax-utils-0.7
+	dev-db/sqlite:3[soundex(+)]
+	net-misc/rsync
+	sys-apps/diffutils
+	sys-apps/sandbox
+	>=sys-apps/portage-2.1.9[${PYTHON_USEDEP}]
+	sys-devel/gettext
+	${PYTHON_DEPS}"
+DEPEND="${RDEPEND}
+	dev-util/intltool"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+S="${S}/lib"
+
+REPO_CONFPATH="${ROOT}/etc/entropy/repositories.conf"
+REPO_D_CONFPATH="${ROOT}/etc/entropy/repositories.conf.d"
+ENTROPY_CACHEDIR="${ROOT}/var/lib/entropy/caches"
+
+pkg_setup() {
+	python-single-r1_pkg_setup
+	# Can:
+	# - update repos
+	# - update security advisories
+	# - handle on-disk cache (atm)
+	enewgroup entropy || die "failed to create entropy group"
+	# Create unprivileged entropy user
+	enewgroup entropy-nopriv || die "failed to create entropy-nopriv group"
+	enewuser entropy-nopriv -1 -1 -1 entropy-nopriv || die "failed to create entropy-nopriv user"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" install || die "make install failed"
+	python_optimize "${D}/usr/lib/entropy/lib/entropy"
+}
+
+pkg_postinst() {
+	for ex_conf in "${REPO_D_CONFPATH}"/_entropy_sabayon-limbo.example; do
+		real_conf="${ex_conf%.example}"
+		if [ -f "${real_conf}" ] || [ -f "${real_conf/_}" ]; then
+			# skip installation then
+			continue
+		fi
+		elog "Installing: ${real_conf}"
+		cp "${ex_conf}" "${real_conf}" -p
+	done
+
+	# Copy config file over
+	if [ -f "${REPO_CONFPATH}.example" ] && [ ! -f "${REPO_CONFPATH}" ]; then
+		elog "Copying ${REPO_CONFPATH}.example over to ${REPO_CONFPATH}"
+		cp "${REPO_CONFPATH}.example" "${REPO_CONFPATH}" -p
+	fi
+
+	if [ -d "${ENTROPY_CACHEDIR}" ]; then
+		einfo "Purging current Entropy cache"
+		rm -rf "${ENTROPY_CACHEDIR}"/*
+	fi
+
+	# Fixup Entropy Resources Lock, and /etc/entropy/packages
+	# files permissions. This fixes unprivileged Entropy Library usage
+	local res_file="${ROOT}"/var/lib/entropy/client/database/*/.using_resources
+	if [ -f "${res_file}" ]; then
+		fowners root:entropy "${res_file}"
+		fperms g+rw "${res_file}"
+		fperms o+r "${res_file}"
+	fi
+	local pkg_files="package.mask package.unmask package.mask.d package.unmask.d"
+	local pkg_file
+	for pkg_file in ${pkg_files}; do
+		pkg_file="${ROOT}/etc/entropy/packages/${pkg_file}"
+		recursive=""
+		if [ -d "${pkg_file}" ]; then
+			recursive="-R"
+		fi
+		if [ -e "${pkg_file}" ]; then
+			fowners ${recursive} root:entropy "${pkg_file}"
+			fperms ${recursive} go+r "${pkg_file}"
+		fi
+	done
+
+	# Setup Entropy Library directories ownership
+	fowners root:entropy "${ROOT}/var/lib/entropy" # no recursion
+	fowners root:entropy "${ROOT}/var/lib/entropy/client/packages" # no recursion
+	fowners root:entropy "${ROOT}/var/log/entropy" # no recursion
+
+	elog "If you want to enable Entropy packages delta download support, please"
+	elog "install dev-util/bsdiff."
+}

--- a/sys-apps/entropy/metadata.xml
+++ b/sys-apps/entropy/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-

--- a/sys-apps/magneto-core/magneto-core-307-r1.ebuild
+++ b/sys-apps/magneto-core/magneto-core-307-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1 multilib
+
+DESCRIPTION="Entropy Package Manager notification applet library"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+S="${WORKDIR}/entropy-${PV}/magneto"
+
+DEPEND="~sys-apps/rigo-daemon-${PV}[${PYTHON_USEDEP}]
+	${PYTHON_DEPS}"
+RDEPEND="${DEPEND}
+	x11-misc/xdg-utils"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" magneto-core-install
+	python_optimize "${D}/usr/$(get_libdir)/entropy/magneto"
+}

--- a/sys-apps/magneto-core/metadata.xml
+++ b/sys-apps/magneto-core/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-

--- a/sys-apps/rigo-daemon/metadata.xml
+++ b/sys-apps/rigo-daemon/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-

--- a/sys-apps/rigo-daemon/rigo-daemon-307-r1.ebuild
+++ b/sys-apps/rigo-daemon/rigo-daemon-307-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1
+
+MY_PN="RigoDaemon"
+DESCRIPTION="Entropy Client DBus Services, aka RigoDaemon"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-3"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+
+S="${WORKDIR}/entropy-${PV}/rigo/${MY_PN}"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="${PYTHON_DEPS}
+	dev-python/dbus-python
+	dev-python/pygobject:3
+	~sys-apps/entropy-${PV}[${PYTHON_USEDEP}]
+	sys-auth/polkit[introspection]
+	sys-devel/gettext"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	python_optimize "${D}/usr/lib/rigo/${MY_PN}"
+}
+
+pkg_preinst() {
+	# ask RigoDaemon to shutdown, if running
+	# TODO: this will be removed in future
+	local shutdown_exec=${EROOT}/usr/lib/rigo/${MY_PN}/shutdown.py
+	[[ -x "${shutdown_exec}" ]] && "${shutdown_exec}"
+}

--- a/x11-misc/magneto-gtk/magneto-gtk-307-r1.ebuild
+++ b/x11-misc/magneto-gtk/magneto-gtk-307-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1
+
+DESCRIPTION="Entropy Package Manager notification applet GTK2 frontend"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+S="${WORKDIR}/entropy-${PV}/magneto"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="~app-misc/magneto-loader-${PV}[${PYTHON_USEDEP}]
+	dev-python/notify-python
+	dev-python/pygtk:2
+	${DEPEND}"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" magneto-gtk-install
+	python_optimize "${D}/usr/lib/entropy/magneto/magneto/gtk"
+}

--- a/x11-misc/magneto-gtk/metadata.xml
+++ b/x11-misc/magneto-gtk/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-

--- a/x11-misc/magneto-gtk3/magneto-gtk3-307-r1.ebuild
+++ b/x11-misc/magneto-gtk3/magneto-gtk3-307-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1
+
+DESCRIPTION="Entropy Package Manager notification applet GTK3 frontend"
+HOMEPAGE="http://www.sabayon.org"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+SRC_URI="mirror://sabayon/sys-apps/entropy-${PV}.tar.bz2"
+S="${WORKDIR}/entropy-${PV}/magneto"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="${DEPEND}
+	~app-misc/magneto-loader-${PV}[${PYTHON_USEDEP}]
+	dev-libs/gobject-introspection
+	x11-libs/gdk-pixbuf[introspection]
+	x11-libs/gtk+:3[introspection]
+	x11-libs/libnotify[introspection]"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+	default
+	python_fix_shebang "${S}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBDIR="usr/lib" magneto-gtk3-install
+	python_optimize "${D}/usr/lib/entropy/magneto/magneto/gtk3"
+}

--- a/x11-misc/magneto-gtk3/metadata.xml
+++ b/x11-misc/magneto-gtk3/metadata.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
+	<maintainer type="person">
+		<email>mudler@gentoo.org</email>
+		<name>Ettore Di Giacinto</name>
+		<description>Assign bugs to him</description>
+	</maintainer>
+	<maintainer type="person">
+                <email>skullbocks@sabayon.org</email>
+                <name>Francesco Ferretti</name>
+        </maintainer>
+	<maintainer type="person">
 		<email>lxnay@gentoo.org</email>
 		<name>Fabio Erculiani</name>
+		<description>CC on bugs</description>
 	</maintainer>
-	<use>
-	</use>
 </pkgmetadata>
-


### PR DESCRIPTION
Since entropy exhibits some strange behaviors if someone want to set the default python interpreter to python3 instead of python2.7 I modified each entropy related ebuild to fix shebangs during the prepare phase.
I tested on my machine these ebuilds so all should be fine but another (fresh) pair of eyes could find something missing.   