### PR TITLE
[gnome-extra/budgie-desktop] Budgie Desktop 10.3.1 Revision

### DIFF
--- a/gnome-extra/budgie-desktop/files/budgie-desktop-fix_gobject_types.patch
+++ b/gnome-extra/budgie-desktop/files/budgie-desktop-fix_gobject_types.patch
@@ -1,0 +1,21 @@
+From 84544363a7e3c65ef4e138c7aebb5eaa3a2e794f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gy=C3=B6rgy=20Ball=C3=B3?= <ballogyor@gmail.com>
+Date: Mon, 24 Apr 2017 15:55:12 +0200
+Subject: [PATCH] Fix typo in meson.build
+
+---
+ docs/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/docs/meson.build b/docs/meson.build
+index 478e5374..5ea868c0 100644
+--- a/docs/meson.build
++++ b/docs/meson.build
+@@ -9,6 +9,6 @@ gnome.gtkdoc(
+     scan_args: [
+         '--ignore-headers=budgie-enums.h',
+     ],
+-    gobject_typesfile : 'bdugie-desktop.types',
++    gobject_typesfile : 'budgie-desktop.types',
+     dependencies: link_libplugin,
+ )


### PR DESCRIPTION
This commit includes a patch to the meson.build file that corrects a spelling error, as well as a rewrite of gnome-extra/budgie-desktop-10.3.1 that utilizes the new meson and ninja-utils eclasses. This should fix issues some users reported upstream about building Budgie Desktop 10.3.1 on Gentoo.