### PR TITLE
[sys-apps/v86d] Fix compilation without sources

### DIFF
--- a/sys-apps/v86d/v86d-0.1.10-r1.ebuild
+++ b/sys-apps/v86d/v86d-0.1.10-r1.ebuild
@@ -43,6 +43,11 @@ src_compile() {
 	# Disable stack protector, as it does not work with klibc (bug #346397).
 	filter-flags -fstack-protector -fstack-protector-all
 	#append-cflags "-nostdinc -I/usr/include -I/usr/local/include"
+	if [ "${KV_DIR}" == "" ] ; then
+		# This fix compilation on a fresh rootfs without linux sources.
+		# In this case use header from linux-headers package.
+		append-cflags "-I/usr/include"
+	fi
 	emake KDIR="${KV_DIR}" || die
 }
 


### PR DESCRIPTION
If there aren't kernel source under /usr KDIR variable is unset
and default include options search include files under /include
while linux-headers files are under /usr/include/ directory.

klcc -O2 -march=x86-64 -pipe -I/include -Ilibs/x86emu -c -o v86.o v86.c
In file included from v86_x86emu.c:4:0:
v86.h:24:27: fatal error: video/uvesafb.h: No such file or directory
 #include <video/uvesafb.h>